### PR TITLE
Add code comments, parametrise hard-coded frame names, publish GRF in foot frame

### DIFF
--- a/pronto_biped_core/package.xml
+++ b/pronto_biped_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_biped_core</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
 
   <description>Description</description>
   <maintainer email="mfallon@robots.ox.ac.uk">Maurice Fallon</maintainer>

--- a/pronto_biped_ros/package.xml
+++ b/pronto_biped_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_biped_ros</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>The pronto_biped_ros package</description>
   <license>LGPLv2.1</license>
 

--- a/pronto_core/include/pronto_core/rigidbody.hpp
+++ b/pronto_core/include/pronto_core/rigidbody.hpp
@@ -23,7 +23,7 @@ static const Eigen::Vector3d g_vec = -g_val * Eigen::Vector3d::UnitZ();
  *
  * The chi part of the state vector represents attitude perturbations (exponential coordinates)
  *
- * velocity, angular velocity, and acceleration are tracked in body coordiates
+ * velocity, angular velocity, and acceleration are tracked in body coordinates
  * acceleration is the "sensed" acceleration including the gravity vector (what an IMU onboard would measure)
  */
 class RigidBodyState {
@@ -173,13 +173,11 @@ public:
   }
 
   static Eigen::Affine3d getTransTwistUnscaled(const Eigen::Vector3d & unscaledAngularVelocity,
-      const Eigen::Vector3d & unscailedLinearVelocity);
+      const Eigen::Vector3d & unscaledLinearVelocity);
 
   static Eigen::Affine3d getTransTwist(const Eigen::Vector3d & angularVelocity, const Eigen::Vector3d & linearVelocity,
       double time);
 
   friend std::ostream& operator<<(std::ostream& output, const RigidBodyState & state);
 };
-
-}
-
+}  // namespace pronto

--- a/pronto_core/package.xml
+++ b/pronto_core/package.xml
@@ -19,9 +19,4 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <test_depend>rosunit</test_depend>
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/pronto_core/package.xml
+++ b/pronto_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>pronto_core</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>
     The pronto_core package contains the EKF and the main 
     modules to perform state estimation, including: inertial, gps, optical

--- a/pronto_core/src/rbis_update_interface.cpp
+++ b/pronto_core/src/rbis_update_interface.cpp
@@ -1,4 +1,5 @@
 #include "pronto_core/rbis_update_interface.hpp"
+#include "pronto_core/rotations.hpp"
 #include <iostream>
 
 namespace pronto {
@@ -39,13 +40,13 @@ void RBISResetUpdate::updateFilter(const RBIS & prior_state, const RBIM & prior_
     std::cerr << "?????????????????????" << std::endl;
 
     std::cerr << "Prior gyro bias: " << prior_state.gyroBias().transpose() << std::endl;
-    Eigen::Vector3d rpy = eigen_utils::getEulerAngles(prior_state.orientation()) * 180.0 / M_PI;
+    Eigen::Vector3d rpy = rotation::getEulerAngles(prior_state.orientation()) * 180.0 / M_PI;
     std::cerr << "Prior accel bias: " << prior_state.accelBias().transpose() << std::endl;
     std::cerr << "Prior roll, pitch, yaw [deg]: " << rpy.transpose() << std::endl;
 
     std::cerr << "Posterior gyro bias: " << posterior_state.gyroBias().transpose() << std::endl;
     std::cerr << "Posterior accel bias: " << posterior_state.accelBias().transpose() << std::endl;
-    rpy = eigen_utils::getEulerAngles(posterior_state.orientation()) * 180.0 / M_PI;
+    rpy = rotation::getEulerAngles(posterior_state.orientation()) * 180.0 / M_PI;
     std::cerr << "Posterior roll, pitch, yaw [deg]: " << rpy.transpose() << std::endl;
 
 

--- a/pronto_core/src/vicon_module.cpp
+++ b/pronto_core/src/vicon_module.cpp
@@ -55,7 +55,7 @@ RBISUpdateInterface* ViconModule::processMessage(const RigidTransform *msg,
     // mild check for invalid vicon data. If the translation is very small
     // we send an invalid update
     if ((local_to_vicon.translation().array().abs() < 1e-5).all()){
-      return NULL;
+      return nullptr;
     }
 
     // no need to break because we return at each case
@@ -82,8 +82,6 @@ RBISUpdateInterface* ViconModule::processMessage(const RigidTransform *msg,
                                                          RBISUpdateInterface::vicon,
                                                          msg->utime);
     case ViconMode::MODE_POSITION_ORIENT:
-
-
         z_meas.head<3>() = local_to_body.translation();
 
         return new RBISIndexedPlusOrientationMeasurement(z_indices,
@@ -93,7 +91,7 @@ RBISUpdateInterface* ViconModule::processMessage(const RigidTransform *msg,
                                                          RBISUpdateInterface::vicon,
                                                          msg->utime);
     default:
-        return NULL;
+        return nullptr;
     }
 
 }

--- a/pronto_msgs/package.xml
+++ b/pronto_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_msgs</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
 
   <description>
 	  The pronto_msgs package contains common message types used by the

--- a/pronto_msgs/package.xml
+++ b/pronto_msgs/package.xml
@@ -8,54 +8,15 @@
 	  Pronto state estimator.
   </description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="mcamurri@robots.ox.ac.uk">Marco Camurri</maintainer>
-
   <license>LGPLv2.1</license>
 
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/pronto_msgs</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
 
-  <!-- Use build_depend for packages you need at compile time: -->
   <build_depend>message_generation</build_depend>
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
   <exec_depend>message_runtime</exec_depend>
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
   <buildtool_depend>catkin</buildtool_depend>
-
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/pronto_msgs/package.xml
+++ b/pronto_msgs/package.xml
@@ -11,9 +11,6 @@
   <maintainer email="mcamurri@robots.ox.ac.uk">Marco Camurri</maintainer>
   <license>LGPLv2.1</license>
 
-  <depend>std_msgs</depend>
-  <depend>geometry_msgs</depend>
-
   <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend>
   <depend>std_msgs</depend>

--- a/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
@@ -47,7 +47,7 @@ public:
 public:
     ImuBiasLock(const Eigen::Isometry3d& ins_to_body_ = Eigen::Isometry3d::Identity(),
                 const ImuBiasLockConfig& cfg = ImuBiasLockConfig());
-    virtual ~ImuBiasLock()  {}
+    virtual ~ImuBiasLock() {}
 
     RBISUpdateInterface* processMessage(const ImuMeasurement *msg,
                                         StateEstimator *est) override;

--- a/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
@@ -47,7 +47,7 @@ public:
 public:
     ImuBiasLock(const Eigen::Isometry3d& ins_to_body_ = Eigen::Isometry3d::Identity(),
                 const ImuBiasLockConfig& cfg = ImuBiasLockConfig());
-    inline virtual ~ImuBiasLock()  {}
+    virtual ~ImuBiasLock()  {}
 
     RBISUpdateInterface* processMessage(const ImuMeasurement *msg,
                                         StateEstimator *est) override;
@@ -61,36 +61,36 @@ public:
 
     void processSecondaryMessage(const pronto::JointState& msg) override;
 public:
-    inline Eigen::Vector3d getCurrentOmega() {
+    inline Eigen::Vector3d getCurrentOmega() const {
       return current_omega_;
     }
-    inline Eigen::Vector3d getCurrentAccel() {
+    inline Eigen::Vector3d getCurrentAccel() const {
       return current_accel_;
     }
-    inline Eigen::Vector3d getCurrentCorrectedAccel() {
+    inline Eigen::Vector3d getCurrentCorrectedAccel() const {
       return current_accel_corrected_;
     }
 
-    inline Eigen::Vector3d getCurrentAccelBias(){
+    inline Eigen::Vector3d getCurrentAccelBias() const {
       return accel_bias_;
     }
-    inline Eigen::Vector3d getCurrentProperAccelBias(){
+    inline Eigen::Vector3d getCurrentProperAccelBias() const {
       return proper_accel_bias_;
     }
-    inline Eigen::Quaterniond getGVec(){
+    inline Eigen::Quaterniond getGVec() const {
       return quat_g_vec;
     }
 
-    inline Eigen::Isometry3d getGravityTransform() {
-        return gravity_transform_;
+    inline Eigen::Isometry3d getGravityTransform() const {
+      return gravity_transform_;
     }
 
-    inline Eigen::Isometry3d getBiasTransform() {
-        return bias_transform_;
+    inline Eigen::Isometry3d getBiasTransform() const {
+      return bias_transform_;
     }
 
-    inline bool getRecordStatus() {
-        return do_record_;
+    inline bool getRecordStatus() const {
+      return do_record_;
     }
 
 
@@ -126,7 +126,6 @@ protected:
     bool isStatic(const pronto::JointState& state);
     Eigen::Vector3d getBias(const std::vector<Eigen::Vector3d>& history) const;
     Eigen::Matrix3d getBiasCovariance(const std::vector<Eigen::Vector3d>& history) const;
-
 };
-}
-}
+}  // namespace quadruped
+}  // namespace pronto

--- a/pronto_quadruped/include/pronto_quadruped/LegOdometer.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/LegOdometer.hpp
@@ -109,13 +109,6 @@ public:
         std::cerr << "[LegOdometer::getOrientation] Function not implemented yet!" << std::endl;
     }
 
-    /**
-     * @brief setGrfDelta sets the latest computed Delta between the current
-     * and the previous GRF. This is relevant to compute the covariance
-     * if the mode IMPACT_SIGMA is used.
-     * @param grf_delta
-     */
-    virtual void setGrfDelta(const LegScalarMap& grf_delta);
 
     // Debugging methods
     void getVelocitiesFromLegs(LegVectorMap & vd) override;

--- a/pronto_quadruped/include/pronto_quadruped/LegOdometer.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/LegOdometer.hpp
@@ -129,7 +129,7 @@ public:
     void setGrf(const LegVectorMap& grf) override;
 
     // Configuration methods
-    virtual void setMode(const SigmaMode  s_mode, const AverageMode a_mode);
+    virtual void setMode(const SigmaMode s_mode, const AverageMode a_mode);
     virtual void getMode(SigmaMode& s_mode, AverageMode& a_mode);
     virtual std::string printMode();
     void setSpeedLimit(const double& limit) override;
@@ -161,7 +161,7 @@ protected:
     LegVectorMap base_vel_leg_;
     LegVectorMap foot_pos_;
 
-    Eigen::Vector3d xd_b_; // estimated velocity, base frame
+    Eigen::Vector3d xd_b_;  ///< estimated velocity, base frame
 
     Eigen::Array4d grf_delta_;
     Eigen::Array4d grf_;

--- a/pronto_quadruped/include/pronto_quadruped/LegOdometer.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/LegOdometer.hpp
@@ -159,7 +159,7 @@ protected:
     Eigen::Array4d grf_delta_;
     Eigen::Array4d grf_;
 
-    double speed_limit_; // upper limit of the absolute norm of the linear velocity
+    double speed_limit_; // upper limit of the absolute norm of the linear velocity [m/s]
 };
 } // namespace quadruped
 } // namespace pronto

--- a/pronto_quadruped/include/pronto_quadruped/LegOdometer.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/LegOdometer.hpp
@@ -127,6 +127,9 @@ public:
     virtual std::string printMode();
     void setSpeedLimit(const double& limit) override;
 
+    FeetJacobians& getFeetJacobians() const { return feet_jacobians_; }
+    ForwardKinematics& getForwardKinematics() const { return forward_kinematics_; }
+
 protected:
     FeetJacobians& feet_jacobians_;
     ForwardKinematics& forward_kinematics_;

--- a/pronto_quadruped/include/pronto_quadruped/LegOdometerBase.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/LegOdometerBase.hpp
@@ -147,8 +147,6 @@ public:
     virtual void setInitVelocityStd(const Vector3d& vel_std) = 0;
     virtual void setInitPositionCov(const Matrix3d& pos_cov) = 0;
 
-    // virtual void getAngularVelocity(Vector3d& omega, Matrix3d& covariance) = 0;
-
     virtual void getVelocitiesFromLegs(LegVectorMap & vd) = 0;
     virtual void getFeetPositions(LegVectorMap & jd) = 0;
 

--- a/pronto_quadruped/include/pronto_quadruped/LegOdometerBase.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/LegOdometerBase.hpp
@@ -62,7 +62,7 @@ public:
      * @param[in] stance_prob a data structure indicating how likely a leg is
      * on the ground (from 0 to 1)
      * @param[out] position robot absolute position, expressed in an absolute
-     * in a absolute reference frame
+     * reference frame
      * @param[out] pos_covariance covariance associated to the position
      * @param[out] orientation quaternion describing the absolute attitude of
      * the robot, expressed in world frame

--- a/pronto_quadruped/include/pronto_quadruped/LegOdometerBase.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/LegOdometerBase.hpp
@@ -147,12 +147,33 @@ public:
     virtual void setInitVelocityStd(const Vector3d& vel_std) = 0;
     virtual void setInitPositionCov(const Matrix3d& pos_cov) = 0;
 
+    /**
+     * @brief Returns the latest estimated base velocity based on each individual leg velocity
+     * 
+     * @param[out] velocity of the base as determined from the leg
+     */
     virtual void getVelocitiesFromLegs(LegVectorMap & vd) = 0;
+
+    /**
+     * @brief Returns the latest estimated foot positions
+     * 
+     * @param[out] position of each foot as LegVectorMap 
+     */
     virtual void getFeetPositions(LegVectorMap & jd) = 0;
 
-  virtual void setGrf(const LegVectorMap& grf) = 0;
+    /**
+     * @brief Sets the ground reaction force in world-aligned orientation from external estimation
+     * 
+     * @param[in] grf ground reaction forces in world-aligned orientation
+     */
+    virtual void setGrf(const LegVectorMap& grf) = 0;
 
-  virtual void setSpeedLimit(const double& /*limit*/) {}
+    /**
+     * @brief Sets the speed limit above which odometry estimates are rejected
+     * 
+     * @param[in] limit velocity limit in m/s
+     */
+    virtual void setSpeedLimit(const double& /*limit*/) {}
 };
 } // namespace quadruped
 } // namespace pronto

--- a/pronto_quadruped/package.xml
+++ b/pronto_quadruped/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_quadruped</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>The pronto_quadruped package</description>
 
   <maintainer email="mcamurri@robots.ox.ac.uk">Marco Camurri</maintainer>

--- a/pronto_quadruped/package.xml
+++ b/pronto_quadruped/package.xml
@@ -4,58 +4,12 @@
   <version>0.2.0</version>
   <description>The pronto_quadruped package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="mcamurri@robots.ox.ac.uk">Marco Camurri</maintainer>
-
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <author email="mcamurri@robots.ox.ac.uk">Marco Camurri</author>
   <license>LGPLv2.1</license>
 
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/pronto_quadruped</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-  <author email="mcamurri@robots.ox.ac.uk">Marco Camurri</author>
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <depend>pronto_quadruped_commons</depend>
   <depend>pronto_core</depend>
   <depend>pronto_utils</depend>
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/pronto_quadruped/src/LegOdometer.cpp
+++ b/pronto_quadruped/src/LegOdometer.cpp
@@ -162,8 +162,8 @@ bool LegOdometer::estimateVelocity(const uint64_t utime,
     vel_cov_ = initial_vel_cov_;
 
     // Recording foot position and base velocity from legs
+    foot_pos_ = forward_kinematics_.getFeetPos(q);
     for(int leg = LF; leg <= RH; leg++){
-        foot_pos_[LegID(leg)] =  forward_kinematics_.getFootPos(q, LegID(leg));
         base_vel_leg_[LegID(leg)] = - feet_jacobians_.getFootJacobian(q, LegID(leg))
                             * qd.block<3,1>(leg * 3, 0)
                             - omega.cross(foot_pos_[LegID(leg)]);
@@ -283,7 +283,7 @@ bool LegOdometer::estimateVelocity(const uint64_t utime,
     var_velocity << vel_std_(0) * vel_std_(0), vel_std_(1) * vel_std_(1), vel_std_(2) * vel_std_(2);
 
     if(debug_) {
-        double impact =  2 * 0.00109375 * abs(grf_delta_.mean());
+        double impact =  2 * 0.00109375 * std::abs(grf_delta_.mean());  // TODO: What is the magic number
         if(impact < 0.001 || std::isnan(impact)) {
             impact = 0.0;
             beta = 1;

--- a/pronto_quadruped/src/LegOdometer.cpp
+++ b/pronto_quadruped/src/LegOdometer.cpp
@@ -150,10 +150,6 @@ void LegOdometer::getFeetPositions(LegVectorMap &jd) {
     jd = foot_pos_;
 }
 
-void LegOdometer::setGrfDelta(const LegScalarMap &grf_delta){
-    grf_delta_ << grf_delta[0] , grf_delta[1] , grf_delta[2], grf_delta[3];
-}
-
 bool LegOdometer::estimateVelocity(const uint64_t utime,
                                    const JointState &q,
                                    const JointState &qd,

--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/declarations.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/declarations.h
@@ -96,9 +96,5 @@ static const JointIdentifiers orderedJointIDs[jointsCount] =
 
 static const LinkIdentifiers orderedLinkIDs[linksCount] =
     {TRUNK,LF_HIPASSEMBLY,LF_UPPERLEG,LF_LOWERLEG,RF_HIPASSEMBLY,RF_UPPERLEG,RF_LOWERLEG,LH_HIPASSEMBLY,LH_UPPERLEG,LH_LOWERLEG,RH_HIPASSEMBLY,RH_UPPERLEG,RH_LOWERLEG};
-
-
-
 }
 }
-

--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/feet_jacobians.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/feet_jacobians.h
@@ -54,10 +54,26 @@ public:
      * takes the identifier of the leg of interest.
      */
     ///@{
+    [[deprecated("This method is deprecated and will be removed. Please use getFootJacobian(q, leg) instead.")]]
     virtual FootJac getFootJacobianLF(const JointState& q) { return getFootJacobian(q, LegID::LF); }
+    [[deprecated("This method is deprecated and will be removed. Please use getFootJacobian(q, leg) instead.")]]
     virtual FootJac getFootJacobianRF(const JointState& q) { return getFootJacobian(q, LegID::RF); }
+    [[deprecated("This method is deprecated and will be removed. Please use getFootJacobian(q, leg) instead.")]]
     virtual FootJac getFootJacobianLH(const JointState& q) { return getFootJacobian(q, LegID::LH); }
+    [[deprecated("This method is deprecated and will be removed. Please use getFootJacobian(q, leg) instead.")]]
     virtual FootJac getFootJacobianRH(const JointState& q) { return getFootJacobian(q, LegID::RH); }
+
+    /**
+     * @brief Get the 3x3 Foot Jacobian
+     * 
+     * This function returns the 3x3 Jacobian that multiplied by the
+     * velocity of the leg joints yields the linear velocity of the foot,
+     * expressed in the base reference frame.
+     * 
+     * @param[in] q Joint congiruation
+     * @param[in] leg Leg identifier
+     * @return FootJac 3x3 foot jacobian
+     */
     virtual FootJac getFootJacobian(const JointState& q, const LegID& leg) = 0;
 
     virtual FootJac getFootJacobianAngular(const pronto::quadruped::JointState& q,

--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/feet_jacobians.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/feet_jacobians.h
@@ -41,6 +41,7 @@ namespace quadruped {
 class FeetJacobians
 {
 public:
+    FeetJacobians() {}
     virtual ~FeetJacobians() {}
 
     /**
@@ -59,12 +60,10 @@ public:
     virtual FootJac getFootJacobianRH(const JointState& q) = 0;
     virtual FootJac getFootJacobian(const JointState& q, const LegID& leg) = 0;
 
-  virtual FootJac getFootJacobianAngular(const pronto::quadruped::JointState& q,
+    virtual FootJac getFootJacobianAngular(const pronto::quadruped::JointState& q,
                                          const pronto::quadruped::LegID& leg) = 0;
     ///@}
 };
 
-
-}
-}
-
+}  // namespace quadruped
+}  // namespace pronto

--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/feet_jacobians.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/feet_jacobians.h
@@ -54,10 +54,10 @@ public:
      * takes the identifier of the leg of interest.
      */
     ///@{
-    virtual FootJac getFootJacobianLF(const JointState& q) = 0;
-    virtual FootJac getFootJacobianRF(const JointState& q) = 0;
-    virtual FootJac getFootJacobianLH(const JointState& q) = 0;
-    virtual FootJac getFootJacobianRH(const JointState& q) = 0;
+    virtual FootJac getFootJacobianLF(const JointState& q) { return getFootJacobian(q, LegID::LF); }
+    virtual FootJac getFootJacobianRF(const JointState& q) { return getFootJacobian(q, LegID::RF); }
+    virtual FootJac getFootJacobianLH(const JointState& q) { return getFootJacobian(q, LegID::LH); }
+    virtual FootJac getFootJacobianRH(const JointState& q) { return getFootJacobian(q, LegID::RH); }
     virtual FootJac getFootJacobian(const JointState& q, const LegID& leg) = 0;
 
     virtual FootJac getFootJacobianAngular(const pronto::quadruped::JointState& q,

--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
@@ -42,8 +42,8 @@ namespace quadruped {
 class ForwardKinematics
 {
 public:
-    ForwardKinematics() {}
-    virtual ~ForwardKinematics() {}
+    ForwardKinematics() = default;
+    virtual ~ForwardKinematics() = default;
 
     virtual Vector3d getFootPosLF(const JointState& q) = 0;
     virtual Vector3d getFootPosRF(const JointState& q) = 0;

--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
@@ -42,6 +42,7 @@ namespace quadruped {
 class ForwardKinematics
 {
 public:
+    ForwardKinematics() {}
     virtual ~ForwardKinematics() {}
 
     virtual Vector3d getFootPosLF(const JointState& q) = 0;

--- a/pronto_quadruped_commons/package.xml
+++ b/pronto_quadruped_commons/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>pronto_quadruped_commons</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>
         pronto_quadruped_commons
   </description>

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/bias_lock_handler_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/bias_lock_handler_ros.hpp
@@ -90,6 +90,7 @@ ImuBiasLockBaseROS<JointStateT>::ImuBiasLockBaseROS(ros::NodeHandle& nh) : nh_(n
   nh_.getParam(ins_param_prefix + "frame", imu_frame);
   std::string base_frame = "base";
   nh.param<std::string>("base_link_name", base_frame, "base");
+  ROS_INFO_STREAM("[ImuBiasLockBaseROS] Name of base_link: '" << base_frame << "'");
   Eigen::Isometry3d ins_to_body = Eigen::Isometry3d::Identity();
   while(nh_.ok()) {
     try {

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/bias_lock_handler_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/bias_lock_handler_ros.hpp
@@ -93,6 +93,7 @@ ImuBiasLockBaseROS<JointStateT>::ImuBiasLockBaseROS(ros::NodeHandle& nh) : nh_(n
   Eigen::Isometry3d ins_to_body = Eigen::Isometry3d::Identity();
   while(nh_.ok()) {
     try {
+      // lookupTransform API is : target_frame, source_frame
       geometry_msgs::TransformStamped temp_transform = tfBuffer.lookupTransform(base_frame, imu_frame, ros::Time(0));
       tf::transformMsgToEigen(temp_transform.transform, ins_to_body);
       ROS_INFO_STREAM("IMU (" << imu_frame <<") to base (" << base_frame << ") transform: translation=(" << ins_to_body.translation().transpose() << "), rotation=(" << ins_to_body.rotation() << ")");

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/conversions.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/conversions.hpp
@@ -1,16 +1,15 @@
 #pragma once
+
 #include <sensor_msgs/JointState.h>
 #include <pronto_quadruped_commons/declarations.h>
 
 namespace pronto {
 namespace quadruped {
-
 bool jointStateFromROS(const sensor_msgs::JointState& msg,
                        uint64_t& utime,
                        JointState& q,
                        JointState& qd,
                        JointState& qdd,
                        JointState& tau);
-
-}
-}
+}  // namespace quadruped
+}  // namespace pronto

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
@@ -45,7 +45,7 @@ class LegodoHandlerBase {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 public:
-    using  LegScalarMap = LegDataMap<double>;
+    using LegScalarMap = LegDataMap<double>;
     using Update = RBISUpdateInterface;
 
 public:
@@ -113,8 +113,6 @@ protected:
 class LegodoHandlerROS : public pronto::SensingModule<sensor_msgs::JointState>,
                          public LegodoHandlerBase
 {
-
-
 public:
     LegodoHandlerROS(ros::NodeHandle& nh,
                      StanceEstimatorBase &stance_est,
@@ -149,7 +147,6 @@ public:
                           RBIM &init_cov) override;
 
   void processSecondaryMessage(const pronto_msgs::QuadrupedForceTorqueSensors &msg) override;
-
 };
 
 class FootSensorLegodoHandlerROS : public LegodoHandlerBase,
@@ -171,7 +168,6 @@ public:
                           RBIM &init_cov) override;
 
   void processSecondaryMessage(const pronto_msgs::QuadrupedStance &msg) override;
-
 };
 
 }  // namespace quadruped

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
@@ -52,15 +52,14 @@ public:
     LegodoHandlerBase(ros::NodeHandle& nh,
                       StanceEstimatorBase& fcf,
                       LegOdometerBase& fj);
+    virtual ~LegodoHandlerBase() = default;
 
 protected:
     StanceEstimatorBase& stance_estimator_;
     LegOdometerBase& leg_odometer_;
 
-    Eigen::Vector3d r_legodo;
-    Eigen::Vector3d R_legodo_init;
-    Eigen::Vector3d r_legodo_init;
-    Eigen::Matrix3d cov_legodo;
+    Eigen::Vector3d r_legodo_;
+    Eigen::Matrix3d cov_legodo_;
 
     JointState q_;
     JointState qd_;
@@ -70,11 +69,11 @@ protected:
     RBIS head_state_;
     RBIM head_cov_;
 
-    Eigen::Vector3d xd_;
-    Eigen::Vector3d xdd_;
-    Eigen::Vector3d omega_;
-    Eigen::Vector3d omegad_;
-    Eigen::Quaterniond orientation_;
+    Eigen::Vector3d xd_;               ///< Linear velocity of the base frame, expressed in inertial frame
+    Eigen::Vector3d xdd_;              ///< Net linear acceleration of the base frame without gravity, expressed in inertial frame
+    Eigen::Vector3d omega_;            ///< Angular velocity of the base, expressed in base frame
+    Eigen::Vector3d omegad_;           ///< Angular acceleration of the base, expressed in base frame
+    Eigen::Quaterniond orientation_;   ///< Orientation of the base with respect to the inertial frame, expressed in base frame
 
     LegBoolMap stance_;
     LegScalarMap stance_prob_;
@@ -117,6 +116,7 @@ public:
     LegodoHandlerROS(ros::NodeHandle& nh,
                      StanceEstimatorBase &stance_est,
                      LegOdometerBase &legodo);
+    virtual ~LegodoHandlerROS() = default;
 
     Update * processMessage(const sensor_msgs::JointState *msg, StateEstimator *est) override;
 
@@ -136,6 +136,7 @@ public:
   ForceSensorLegodoHandlerROS(ros::NodeHandle& nh,
                               StanceEstimatorBase& stance_est,
                               LegOdometerBase& legodo);
+  virtual ~ForceSensorLegodoHandlerROS() = default;
 
   Update * processMessage(const sensor_msgs::JointState *msg, StateEstimator *est) override;
 
@@ -157,6 +158,7 @@ public:
   FootSensorLegodoHandlerROS(ros::NodeHandle& nh,
                              StanceEstimatorBase& stance_est,
                              LegOdometerBase& legodo);
+  virtual ~FootSensorLegodoHandlerROS() = default;
 
   Update * processMessage(const sensor_msgs::JointState *msg, StateEstimator *est) override;
 

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
@@ -58,6 +58,9 @@ protected:
     StanceEstimatorBase& stance_estimator_;
     LegOdometerBase& leg_odometer_;
 
+    std::string base_link_name_;           ///< Name of the base_link
+    std::vector<std::string> foot_names_;  ///< Name of the feet frames (in LF, RF, LH, RH order)
+
     Eigen::Vector3d r_legodo_;
     Eigen::Matrix3d cov_legodo_;
 

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
@@ -88,8 +88,10 @@ protected:
     uint16_t downsample_factor_;
     uint64_t utime_offset_;
 
+    // Debug Publishers
     std::vector<ros::Publisher> vel_debug_;
     std::vector<ros::Publisher> grf_debug_;
+    std::vector<ros::Publisher> grf_in_foot_frame_debug_;
     ros::Publisher vel_raw_;
     ros::Publisher prior_joint_accel_debug_;
     ros::Publisher prior_velocity_debug_;

--- a/pronto_quadruped_ros/package.xml
+++ b/pronto_quadruped_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_quadruped_ros</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>The pronto_quadruped_ros package</description>
 
   <author email="mcamurri@robots.ox.ac.uk">Marco Camurri</author>

--- a/pronto_quadruped_ros/package.xml
+++ b/pronto_quadruped_ros/package.xml
@@ -23,9 +23,4 @@
   <depend>pronto_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>eigen_conversions</depend>
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/pronto_quadruped_ros/src/conversions.cpp
+++ b/pronto_quadruped_ros/src/conversions.cpp
@@ -13,10 +13,13 @@ bool jointStateFromROS(const sensor_msgs::JointState& msg,
 {
     // if the size of the joint state message does not match our own,
     // we silently return an invalid update
-    if(static_cast<int>(static_cast<const sensor_msgs::JointState&>(msg).position.size()) != q.rows()*q.cols()){
+    if (static_cast<int>(static_cast<const sensor_msgs::JointState&>(msg).position.size()) != q.size() ||
+        static_cast<int>(static_cast<const sensor_msgs::JointState&>(msg).velocity.size()) != q.size() ||
+        static_cast<int>(static_cast<const sensor_msgs::JointState&>(msg).effort.size()) != q.size()){
         ROS_WARN_STREAM_THROTTLE(1, "Joint State is expected " << \
-                                 q.rows()*q.cols() << " joints but "\
-                                 << msg.position.size() << " are provided.");
+                                 q.size() << " joints but "\
+                                 << msg.position.size() << " / " << msg.velocity.size() << " / " << msg.effort.size()
+                                 << " are provided.");
         return false;
     }
     // store message time in microseconds
@@ -30,7 +33,8 @@ bool jointStateFromROS(const sensor_msgs::JointState& msg,
     //qd = Eigen::Map<const JointState>(msg.velocity.data());
     //tau = Eigen::Map<const JointState>(msg.effort.data());
 
-    qdd = JointState::Zero(); // TODO compute the acceleration
+    qdd.setZero(); // TODO compute the acceleration
+
     return true;
 }
 

--- a/pronto_quadruped_ros/src/conversions.cpp
+++ b/pronto_quadruped_ros/src/conversions.cpp
@@ -34,11 +34,5 @@ bool jointStateFromROS(const sensor_msgs::JointState& msg,
     return true;
 }
 
-
-}
-}
-
-
-
-
-
+}  // namespace quadruped
+}  // namespace pronto

--- a/pronto_quadruped_ros/src/leg_odometer_ros.cpp
+++ b/pronto_quadruped_ros/src/leg_odometer_ros.cpp
@@ -69,5 +69,5 @@ LegOdometerROS::LegOdometerROS(ros::NodeHandle &nh,
     }
 }
 
-}
-}
+}  // namespace quadruped
+}  // namespace pronto

--- a/pronto_quadruped_ros/src/legodo_handler_ros.cpp
+++ b/pronto_quadruped_ros/src/legodo_handler_ros.cpp
@@ -379,7 +379,7 @@ LegodoHandlerBase::Update * ForceSensorLegodoHandlerROS::processMessage(const se
   return computeVelocity();
 }
 
-bool ForceSensorLegodoHandlerROS::processMessageInit(const sensor_msgs::JointState */*msg*/, const std::map<std::string, bool> &/*sensor_initialized*/, const RBIS &/*default_state*/, const RBIM &/*default_cov*/, RBIS &/*init_state*/, RBIM &/*init_cov*/){
+bool ForceSensorLegodoHandlerROS::processMessageInit(const sensor_msgs::JointState* /*msg*/, const std::map<std::string, bool>& /*sensor_initialized*/, const RBIS& /*default_state*/, const RBIM& /*default_cov*/, RBIS& /*init_state*/, RBIM& /*init_cov*/){
   return true;
 }
 

--- a/pronto_quadruped_ros/src/legodo_handler_ros.cpp
+++ b/pronto_quadruped_ros/src/legodo_handler_ros.cpp
@@ -160,13 +160,13 @@ LegodoHandlerBase::Update* LegodoHandlerBase::computeVelocity(){
 
       prior_accel_msg.header.frame_id = base_link_name_;
       prior_accel_msg.header.stamp = ros::Time().fromNSec(nsec_);
-      prior_accel_msg.accel.linear.x = xdd_(0);
-      prior_accel_msg.accel.linear.y = xdd_(1);
-      prior_accel_msg.accel.linear.z = xdd_(2);
+      prior_accel_msg.accel.linear.x = xdd_.x();
+      prior_accel_msg.accel.linear.y = xdd_.y();
+      prior_accel_msg.accel.linear.z = xdd_.z();
 
-      prior_accel_msg.accel.angular.x = omegad_(0);
-      prior_accel_msg.accel.angular.y = omegad_(1);
-      prior_accel_msg.accel.angular.z = omegad_(2);
+      prior_accel_msg.accel.angular.x = omegad_.x();
+      prior_accel_msg.accel.angular.y = omegad_.y();
+      prior_accel_msg.accel.angular.z = omegad_.z();
 
       prior_accel_debug_.publish(prior_accel_msg);
 
@@ -190,13 +190,13 @@ LegodoHandlerBase::Update* LegodoHandlerBase::computeVelocity(){
       geometry_msgs::TwistStamped prior_vel_msg;
       prior_vel_msg.header.frame_id = base_link_name_;
       prior_vel_msg.header.stamp = ros::Time().fromNSec(nsec_);
-      prior_vel_msg.twist.linear.x = xd_(0);
-      prior_vel_msg.twist.linear.y = xd_(1);
-      prior_vel_msg.twist.linear.z = xd_(2);
+      prior_vel_msg.twist.linear.x = xd_.x();
+      prior_vel_msg.twist.linear.y = xd_.y();
+      prior_vel_msg.twist.linear.z = xd_.z();
 
-      prior_vel_msg.twist.angular.x = omega_(0);
-      prior_vel_msg.twist.angular.y = omega_(1);
-      prior_vel_msg.twist.angular.z = omega_(2);
+      prior_vel_msg.twist.angular.x = omega_.x();
+      prior_vel_msg.twist.angular.y = omega_.y();
+      prior_vel_msg.twist.angular.z = omega_.z();
       prior_velocity_debug_.publish(prior_vel_msg);
   }
 
@@ -238,16 +238,16 @@ LegodoHandlerBase::Update* LegodoHandlerBase::computeVelocity(){
 
           // publish the estimated velocity for each individual leg
           for(int i=0; i<4; i++){
-              twist.twist.linear.x = veldebug[LegID(i)](0);
-              twist.twist.linear.y = veldebug[LegID(i)](1);
-              twist.twist.linear.z = veldebug[LegID(i)](2);
+              twist.twist.linear.x = veldebug[LegID(i)].x();
+              twist.twist.linear.y = veldebug[LegID(i)].y();
+              twist.twist.linear.z = veldebug[LegID(i)].z();
               vel_debug_[i].publish(twist);
           }
           // publish the estimated velocity from the leg odometer
           // before it gets passed to the filter
-          twist.twist.linear.x = xd_(0);
-          twist.twist.linear.y = xd_(1);
-          twist.twist.linear.z = xd_(2);
+          twist.twist.linear.x = xd_.x();
+          twist.twist.linear.y = xd_.y();
+          twist.twist.linear.z = xd_.z();
 
           vel_raw_.publish(twist);
       }
@@ -291,12 +291,12 @@ LegodoHandlerROS::Update* LegodoHandlerROS::processMessage(const sensor_msgs::Jo
     return computeVelocity();
 }
 
-bool LegodoHandlerROS::processMessageInit(const sensor_msgs::JointState */*msg*/,
-                                          const std::map<std::string, bool> &/*sensor_initialized*/,
-                                          const RBIS &/*default_state*/,
-                                          const RBIM &/*default_cov*/,
-                                          RBIS &/*init_state*/,
-                                          RBIM &/*init_cov*/)
+bool LegodoHandlerROS::processMessageInit(const sensor_msgs::JointState* /*msg*/,
+                                          const std::map<std::string, bool>& /*sensor_initialized*/,
+                                          const RBIS& /*default_state*/,
+                                          const RBIM& /*default_cov*/,
+                                          RBIS& /*init_state*/,
+                                          RBIM& /*init_cov*/)
 {
     // do nothing for now, we don't expect to initialize with the leg odometry
     return true;
@@ -309,12 +309,12 @@ FootSensorLegodoHandlerROS::FootSensorLegodoHandlerROS(ros::NodeHandle& nh,
 {
 }
 
-bool FootSensorLegodoHandlerROS::processMessageInit(const sensor_msgs::JointState */*msg*/,
-                                                    const std::map<std::string, bool> &/*sensor_initialized*/,
-                                                    const RBIS &/*default_state*/,
-                                                    const RBIM &/*default_cov*/,
-                                                    RBIS &/*init_state*/,
-                                                    RBIM &/*init_cov*/)
+bool FootSensorLegodoHandlerROS::processMessageInit(const sensor_msgs::JointState* /*msg*/,
+                                                    const std::map<std::string, bool>& /*sensor_initialized*/,
+                                                    const RBIS& /*default_state*/,
+                                                    const RBIM& /*default_cov*/,
+                                                    RBIS& /*init_state*/,
+                                                    RBIM& /*init_cov*/)
 {
   return true;
 }

--- a/pronto_quadruped_ros/src/legodo_handler_ros.cpp
+++ b/pronto_quadruped_ros/src/legodo_handler_ros.cpp
@@ -73,6 +73,13 @@ LegodoHandlerBase::LegodoHandlerBase(ros::NodeHandle &nh,
     // }
     // imu_sub_ = nh_.subscribe(imu_topic_, 100, &LegodoHandlerROS::imuCallback, this);
 
+    nh.param<std::string>("base_link_name", base_link_name_, "base");
+    foot_names_.resize(4);
+    nh.param<std::string>("LF_FOOT_name", foot_names_[0], "LF_FOOT");
+    nh.param<std::string>("RF_FOOT_name", foot_names_[1], "RF_FOOT");
+    nh.param<std::string>("LH_FOOT_name", foot_names_[2], "LH_FOOT");
+    nh.param<std::string>("RH_FOOT_name", foot_names_[3], "RH_FOOT");
+
     const std::vector<std::string> leg_names = {"lf", "rf", "lh", "rh"};
     if(debug_){
         for(int i=0; i<4; i++){
@@ -151,7 +158,7 @@ LegodoHandlerBase::Update* LegodoHandlerBase::computeVelocity(){
       // Publish prior accel
       geometry_msgs::AccelStamped prior_accel_msg;
 
-      prior_accel_msg.header.frame_id = "base";  // TODO: Expose base frame as parameter
+      prior_accel_msg.header.frame_id = base_link_name_;
       prior_accel_msg.header.stamp = ros::Time().fromNSec(nsec_);
       prior_accel_msg.accel.linear.x = xdd_(0);
       prior_accel_msg.accel.linear.y = xdd_(1);
@@ -181,7 +188,7 @@ LegodoHandlerBase::Update* LegodoHandlerBase::computeVelocity(){
 
       // Publish prior velocity
       geometry_msgs::TwistStamped prior_vel_msg;
-      prior_vel_msg.header.frame_id = "base";  // TODO: Expose base frame as parameter
+      prior_vel_msg.header.frame_id = base_link_name_;
       prior_vel_msg.header.stamp = ros::Time().fromNSec(nsec_);
       prior_vel_msg.twist.linear.x = xd_(0);
       prior_vel_msg.twist.linear.y = xd_(1);

--- a/pronto_ros/package.xml
+++ b/pronto_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_ros</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>The pronto_ros package</description>
 
   <author email="mcamurri@robots.ox.ac.uk">Marco Camurri</author>

--- a/pronto_ros/src/ins_ros_handler.cpp
+++ b/pronto_ros/src/ins_ros_handler.cpp
@@ -16,19 +16,18 @@ InsHandlerROS::InsHandlerROS(ros::NodeHandle &nh) : nh_(nh)
     std::string imu_frame = "imu";
 
     nh_.getParam(ins_param_prefix + "frame", imu_frame);
-    const std::string base_frame = "base";
-    Eigen::Affine3d ins_to_body;
-    while(nh_.ok()){
-        try{
-            geometry_msgs::TransformStamped temp_transform;
-            temp_transform = tf_imu_to_body_buffer_.lookupTransform(base_frame, imu_frame, ros::Time(0));
-
+    std::string base_frame = "base";
+    nh_.param<std::string>("base_link_name", base_frame, "base");
+    Eigen::Isometry3d ins_to_body = Eigen::Isometry3d::Identity();
+    while(nh_.ok()) {
+        try {
+            geometry_msgs::TransformStamped temp_transform = tf_imu_to_body_buffer_.lookupTransform(base_frame, imu_frame, ros::Time(0));
             tf::transformMsgToEigen(temp_transform.transform, ins_to_body);
-            ROS_INFO_STREAM("IMU to base transform: translation=(" << ins_to_body.translation().transpose() << "), rotation=(" << ins_to_body.rotation() << ")");
-
+            ROS_INFO_STREAM("IMU (" << imu_frame <<") to base (" << base_frame << ") transform: translation=(" << ins_to_body.translation().transpose() << "), rotation=(" << ins_to_body.rotation() << ")");
             break;
-        } catch (const tf2::TransformException& ex){
-            ROS_ERROR("%s",ex.what());
+        }
+        catch (const tf2::TransformException& ex) {
+            ROS_ERROR("%s", ex.what());
             ros::Duration(1.0).sleep();
         }
     }

--- a/pronto_ros/src/ins_ros_handler.cpp
+++ b/pronto_ros/src/ins_ros_handler.cpp
@@ -18,6 +18,7 @@ InsHandlerROS::InsHandlerROS(ros::NodeHandle &nh) : nh_(nh)
     nh_.getParam(ins_param_prefix + "frame", imu_frame);
     std::string base_frame = "base";
     nh_.param<std::string>("base_link_name", base_frame, "base");
+    ROS_INFO_STREAM("[InsHandlerROS] Name of base_link: '" << base_frame << "'");
     Eigen::Isometry3d ins_to_body = Eigen::Isometry3d::Identity();
     while(nh_.ok()) {
         try {

--- a/pronto_utils/package.xml
+++ b/pronto_utils/package.xml
@@ -6,14 +6,7 @@
   <maintainer email="mcamurri@robots.ox.ac.uk">Marco Camurri</maintainer>
   <author email="mfallon@robots.ox.ac.uk">Maurice Fallon</author>
   <author email="mcamurri@robots.ox.ac.uk">Marco Camurri</author>
-
-
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>LGPLv2</license>
-
-
+  <license>LGPLv2.1</license>
   <buildtool_depend>catkin</buildtool_depend>
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export />
+  <depend>eigen</depend>
 </package>

--- a/pronto_utils/package.xml
+++ b/pronto_utils/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>pronto_utils</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>Description</description>
   <maintainer email="mcamurri@robots.ox.ac.uk">Marco Camurri</maintainer>
   <author email="mfallon@robots.ox.ac.uk">Maurice Fallon</author>

--- a/pronto_utils/package.xml
+++ b/pronto_utils/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>pronto_utils</name>
   <version>0.2.0</version>
   <description>Description</description>


### PR DESCRIPTION
- Added code comments or doxygen to methods upon reading the code / debugging
- Added new parameters `base_link_name`, `LF_FOOT_name`, ... to generalise to other robots without having to modify the URDFs - i.e. it is no longer required to add `base`, `imu_link`, and `LF_FOOT`, ... to the URDFs
- Removed unused hard-coded code fragments (e.g. Anymal IMU location which gets immediately overwritten by a tf lookup)
- Simplified interface for ForwardKinematics / FeetJacobians to avoid repetitive implementation where not required (default virtuals)
- Added additional publishers to leg odometry to publish the ground reaction force in link frame: This enables visualisation of the GRF in RViz using the default Wrench plugin. The existing behaviour of publishing in world-aligned frame for plotting/logging is preserved. Screenshot of RViz with Solo12 below

![image](https://user-images.githubusercontent.com/1664508/120364844-9f4fec00-c305-11eb-8cf8-56b231dbd7ad.png)
