### PR TITLE
Simplify ForwardKinematics interface, improve ImuBiasLock debug output and performance

### DIFF
--- a/pronto_biped_ros/src/legodo_handler_ros.cpp
+++ b/pronto_biped_ros/src/legodo_handler_ros.cpp
@@ -211,6 +211,5 @@ void LegOdometryHandler::forceTorqueCallback(const pronto_msgs::BipedForceTorque
   legodo_module_->setForceTorque(ft_msg_);
 }
 
-}
-}
-
+}  // namespace biped
+}  // namespace pronto

--- a/pronto_core/src/visual_odometry_module.cpp
+++ b/pronto_core/src/visual_odometry_module.cpp
@@ -87,4 +87,4 @@ bool VisualOdometryModule::processMessageInit(const VisualOdometryUpdate *msg,
     // we shouldn't initialize from VO
     return true;
 }
-}
+}  // namespace pronto

--- a/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
@@ -95,6 +95,7 @@ public:
 
 
 protected:
+    bool debug_ = false;
     std::vector <Eigen::Vector3d> gyro_bias_history_;
     std::vector <Eigen::Vector3d> accel_bias_history_;
     bool do_record_ = true;

--- a/pronto_quadruped/src/ImuBiasLock.cpp
+++ b/pronto_quadruped/src/ImuBiasLock.cpp
@@ -68,7 +68,7 @@ RBISUpdateInterface* ImuBiasLock::processMessage(const ImuMeasurement *msg,
     gyro_bias_history_.push_back(current_omega_);
     accel_bias_history_.push_back(current_accel_corrected_);
     if(gyro_bias_history_.size() > max_size){
-      std::cout << "Stop recording (size too big)" << "\n";
+      std::cout << "Stop recording (size too big)\n";
       std::cout << gyro_bias_history_.size() << "\n";
       do_record_ = false;
     } else {
@@ -123,12 +123,12 @@ void ImuBiasLock::processSecondaryMessage(const pronto::JointState &msg){
 
   if(do_record_ && !is_static_){
       if (debug_) {
-        std::cout << " history is " << gyro_bias_history_.size() << " long" << "\n";
-        std::cout << "+++++++++++++++++++ STOP ESTIMATING" << "\n";
+        std::cout << " history is " << gyro_bias_history_.size() << " long\n";
+        std::cout << "+++++++++++++++++++ STOP ESTIMATING\n";
       }
       do_record_ = false;
   } else if (!do_record_ && is_static_){
-      if (debug_) std::cout << "+++++++++++++++++++ ESTIMATING BIAS" << "\n";
+      if (debug_) std::cout << "+++++++++++++++++++ ESTIMATING BIAS\n";
       do_record_ = true;
   }
 }
@@ -137,7 +137,7 @@ bool ImuBiasLock::isStatic(const pronto::JointState &state)
 {
   // check if we are in four contact (poor's man version, knee torque threshold)
   if(state.joint_effort.size() < 12){
-    std::cerr << "++++++++++++++ not enough joints " << state.joint_effort.size() << " < 12 !!!" << "\n";
+    std::cerr << "++++++++++++++ not enough joints " << state.joint_effort.size() << " < 12 !!!\n";
     return false;
   }
 

--- a/pronto_quadruped/src/ImuBiasLock.cpp
+++ b/pronto_quadruped/src/ImuBiasLock.cpp
@@ -68,8 +68,8 @@ RBISUpdateInterface* ImuBiasLock::processMessage(const ImuMeasurement *msg,
     gyro_bias_history_.push_back(current_omega_);
     accel_bias_history_.push_back(current_accel_corrected_);
     if(gyro_bias_history_.size() > max_size){
-      std::cout << "Stop recording (size too big)\n";
-      std::cout << gyro_bias_history_.size() << "\n";
+      std::cout << "Stop recording (size too big)" << std::endl;
+      std::cout << gyro_bias_history_.size() << std::endl;
       do_record_ = false;
     } else {
       return nullptr;
@@ -81,7 +81,7 @@ RBISUpdateInterface* ImuBiasLock::processMessage(const ImuMeasurement *msg,
   if(!do_record_ && !gyro_bias_history_.empty()) {
     if(gyro_bias_history_.size() < min_size)
     {
-      std::cerr << "Cleaning too short history " << gyro_bias_history_.size() << " < " << min_size << "\n";
+      std::cerr << "Cleaning too short history " << gyro_bias_history_.size() << " < " << min_size << std::endl;
       gyro_bias_history_.clear();
       accel_bias_history_.clear();
       return nullptr;

--- a/pronto_quadruped/src/ImuBiasLock.cpp
+++ b/pronto_quadruped/src/ImuBiasLock.cpp
@@ -169,26 +169,25 @@ bool ImuBiasLock::isStatic(const pronto::JointState &state)
   return true;
 }
 
-Eigen::Matrix3d ImuBiasLock::getBiasCovariance(const std::vector<Eigen::Vector3d> &history) const{
-  {
-      Eigen::Vector3d mean = getBias(history);
-      Eigen::Matrix3d covariance(Eigen::Matrix3d::Zero());
+Eigen::Matrix3d ImuBiasLock::getBiasCovariance(const std::vector<Eigen::Vector3d> &history) const
+{
+  Eigen::Vector3d mean = getBias(history);
+  Eigen::Matrix3d covariance(Eigen::Matrix3d::Zero());
 
-      for( auto el : history){
-          covariance += (el - mean) * (el - mean).transpose();
-      }
-
-      return covariance / ((double)(history.size() - 1));
+  for( auto el : history){
+    covariance += (el - mean) * (el - mean).transpose();
   }
+
+  return covariance / ((double)(history.size() - 1));
 }
 
 Eigen::Vector3d ImuBiasLock::getBias(const std::vector<Eigen::Vector3d> &history) const
 {
-       Eigen::Vector3d bias(Eigen::Vector3d::Zero());
-       for(auto& el : history) {
-           bias += el;
-       }
-       return bias / ((double)history.size());
+  Eigen::Vector3d bias(Eigen::Vector3d::Zero());
+  for(auto& el : history) {
+    bias += el;
+  }
+  return bias / ((double)history.size());
 }
 
 }  // namespace quadruped

--- a/pronto_quadruped/src/ImuBiasLock.cpp
+++ b/pronto_quadruped/src/ImuBiasLock.cpp
@@ -23,6 +23,7 @@
 #include "pronto_quadruped/ImuBiasLock.hpp"
 #include <pronto_core/rotations.hpp>
 #include <iostream>
+
 namespace pronto {
 namespace quadruped {
 
@@ -48,26 +49,27 @@ ImuBiasLock::ImuBiasLock(const Eigen::Isometry3d& ins_to_body,
   bias_transform_ = Eigen::Isometry3d::Identity();
   gravity_transform_ = Eigen::Isometry3d::Identity();
 
+  gyro_bias_history_.reserve(max_size + 1);
+  accel_bias_history_.reserve(max_size + 1);
 }
 
 RBISUpdateInterface* ImuBiasLock::processMessage(const ImuMeasurement *msg,
                                                  StateEstimator *est)
 {
-
   RBIS prior;
   RBIM prior_cov;
   est->getHeadState(prior, prior_cov);
 
-  current_omega_ = ins_to_body_.rotation()*msg->omega;
-  current_accel_ = ins_to_body_.rotation()*msg->acceleration;
+  current_omega_.noalias() = ins_to_body_.rotation()*msg->omega;
+  current_accel_.noalias() = ins_to_body_.rotation()*msg->acceleration;
   current_accel_corrected_ = current_accel_ - (rotation::skewHat((current_omega_ - previous_omega_) / dt_) + rotation::skewHat(current_omega_)*rotation::skewHat(current_omega_))*ins_to_body_.translation();
   previous_omega_ = current_omega_;
   if(do_record_){
     gyro_bias_history_.push_back(current_omega_);
     accel_bias_history_.push_back(current_accel_corrected_);
     if(gyro_bias_history_.size() > max_size){
-      std::cout << "Stop recording (size too big)" << std::endl;
-      std::cout << gyro_bias_history_.size() << std::endl;
+      std::cout << "Stop recording (size too big)" << "\n";
+      std::cout << gyro_bias_history_.size() << "\n";
       do_record_ = false;
     } else {
       return nullptr;
@@ -79,7 +81,7 @@ RBISUpdateInterface* ImuBiasLock::processMessage(const ImuMeasurement *msg,
   if(!do_record_ && !gyro_bias_history_.empty()) {
     if(gyro_bias_history_.size() < min_size)
     {
-      std::cerr << "Cleaning too short history " << gyro_bias_history_.size() << " < " << min_size << std::endl;
+      std::cerr << "Cleaning too short history " << gyro_bias_history_.size() << " < " << min_size << "\n";
       gyro_bias_history_.clear();
       accel_bias_history_.clear();
       return nullptr;
@@ -120,44 +122,47 @@ void ImuBiasLock::processSecondaryMessage(const pronto::JointState &msg){
   is_static_ = isStatic(msg);
 
   if(do_record_ && !is_static_){
-      // std::cout << " history is " << gyro_bias_history_.size() << " long" << std::endl;
-      // std::cout << "+++++++++++++++++++ STOP ESTIMATING" << std::endl;
+      if (debug_) {
+        std::cout << " history is " << gyro_bias_history_.size() << " long" << "\n";
+        std::cout << "+++++++++++++++++++ STOP ESTIMATING" << "\n";
+      }
       do_record_ = false;
   } else if (!do_record_ && is_static_){
-      // std::cout << "+++++++++++++++++++ ESTIMATING BIAS" << std::endl;
+      if (debug_) std::cout << "+++++++++++++++++++ ESTIMATING BIAS" << "\n";
       do_record_ = true;
   }
 }
 
 bool ImuBiasLock::isStatic(const pronto::JointState &state)
 {
-  // check if we are in four contact (poor's man version, knee torque threshoold)
+  // check if we are in four contact (poor's man version, knee torque threshold)
   if(state.joint_effort.size() < 12){
-//    std::cout << "++++++++++++++ not enough joints " << state.joint_effort.size() << " < " << torque_threshold_<< std::endl;
+    std::cerr << "++++++++++++++ not enough joints " << state.joint_effort.size() << " < 12 !!!" << "\n";
     return false;
   }
 
+  // TODO: The knee joint order is hard-coded here!
   if(std::abs(state.joint_effort[2]) < torque_threshold_){
-  //  std::cout << "++++++++++++++ not enough torque " << std::abs(state.joint_effort[2]) << " < " << torque_threshold_ << std::endl;
+    if (debug_) std::cout << "++++++++++++++ [LF] not enough torque " << std::abs(state.joint_effort[2]) << " < " << torque_threshold_ << "\n";
     return false;
   }
   if(std::abs(state.joint_effort[5]) < torque_threshold_){
-  //  std::cout << "++++++++++++++ not enough torque " << std::abs(state.joint_effort[5]) << " < " << torque_threshold_ << std::endl;
+    if (debug_) std::cout << "++++++++++++++ [RF] not enough torque " << std::abs(state.joint_effort[5]) << " < " << torque_threshold_ << "\n";
     return false;
   }
   if(std::abs(state.joint_effort[8]) < torque_threshold_){
-  //  std::cout << "++++++++++++++ not enough torque " << std::abs(state.joint_effort[8]) << " < " << torque_threshold_ << std::endl;
+    if (debug_) std::cout << "++++++++++++++ [LH] not enough torque " << std::abs(state.joint_effort[8]) << " < " << torque_threshold_ << "\n";
     return false;
   }
   if(std::abs(state.joint_effort[11]) < torque_threshold_){
-  //  std::cout << "++++++++++++++ not enough torque " << std::abs(state.joint_effort[11]) << " < " << torque_threshold_ << std::endl;
+    if (debug_) std::cout << "++++++++++++++ [RH] not enough torque " << std::abs(state.joint_effort[11]) << " < " << torque_threshold_ << "\n";
     return false;
   }
 
   // check that joint velocities are not bigger than eps
   for (auto el : state.joint_velocity){
     if (std::abs(el) > eps_){
-    //  std::cout << "++++++++++++++ too much velocity " << std::abs(el) << " > " << eps_ << std::endl;
+      if (debug_) std::cout << "++++++++++++++ too much velocity " << std::abs(el) << " > " << eps_ << "\n";
       return false;
     }
   }

--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
@@ -45,9 +45,13 @@ public:
     ForwardKinematics() = default;
     virtual ~ForwardKinematics() = default;
 
+    [[deprecated("This method is deprecated and will be removed. Please use getFootPos(q, LegID::LF) instead.")]]
     virtual Vector3d getFootPosLF(const JointState& q) { return getFootPos(q, LegID::LF); }
+    [[deprecated("This method is deprecated and will be removed. Please use getFootPos(q, LegID::RF) instead.")]]
     virtual Vector3d getFootPosRF(const JointState& q) { return getFootPos(q, LegID::RF); }
+    [[deprecated("This method is deprecated and will be removed. Please use getFootPos(q, LegID::LH) instead.")]]
     virtual Vector3d getFootPosLH(const JointState& q) { return getFootPos(q, LegID::LH); }
+    [[deprecated("This method is deprecated and will be removed. Please use getFootPos(q, LegID::RH) instead.")]]
     virtual Vector3d getFootPosRH(const JointState& q) { return getFootPos(q, LegID::RH); }
     virtual Vector3d getFootPos  (const JointState& q, const LegID& leg) = 0;
     inline virtual LegVectorMap getFeetPos(const JointState& q)

--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
@@ -45,18 +45,18 @@ public:
     ForwardKinematics() = default;
     virtual ~ForwardKinematics() = default;
 
-    virtual Vector3d getFootPosLF(const JointState& q) = 0;
-    virtual Vector3d getFootPosRF(const JointState& q) = 0;
-    virtual Vector3d getFootPosLH(const JointState& q) = 0;
-    virtual Vector3d getFootPosRH(const JointState& q) = 0;
+    virtual Vector3d getFootPosLF(const JointState& q) { return getFootPos(q, LegID::LF); }
+    virtual Vector3d getFootPosRF(const JointState& q) { return getFootPos(q, LegID::RF); }
+    virtual Vector3d getFootPosLH(const JointState& q) { return getFootPos(q, LegID::LH); }
+    virtual Vector3d getFootPosRH(const JointState& q) { return getFootPos(q, LegID::RH); }
     virtual Vector3d getFootPos  (const JointState& q, const LegID& leg) = 0;
     inline virtual LegVectorMap getFeetPos(const JointState& q)
     {
         LegVectorMap feetPos(Vector3d::Zero());
-        feetPos[quadruped::LF] = getFootPosLF(q);
-        feetPos[quadruped::RF] = getFootPosRF(q);
-        feetPos[quadruped::LH] = getFootPosLH(q);
-        feetPos[quadruped::RH] = getFootPosRH(q);
+        feetPos[quadruped::LF] = getFootPos(q, LegID::LF);
+        feetPos[quadruped::RF] = getFootPos(q, LegID::RF);
+        feetPos[quadruped::LH] = getFootPos(q, LegID::LH);
+        feetPos[quadruped::RH] = getFootPos(q, LegID::RH);
         return feetPos;
     }
     virtual Matrix3d getFootOrientation(const JointState& q, const LegID& leg) = 0;

--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
@@ -45,14 +45,6 @@ public:
     ForwardKinematics() = default;
     virtual ~ForwardKinematics() = default;
 
-    [[deprecated("This method is deprecated and will be removed. Please use getFootPos(q, LegID::LF) instead.")]]
-    virtual Vector3d getFootPosLF(const JointState& q) { return getFootPos(q, LegID::LF); }
-    [[deprecated("This method is deprecated and will be removed. Please use getFootPos(q, LegID::RF) instead.")]]
-    virtual Vector3d getFootPosRF(const JointState& q) { return getFootPos(q, LegID::RF); }
-    [[deprecated("This method is deprecated and will be removed. Please use getFootPos(q, LegID::LH) instead.")]]
-    virtual Vector3d getFootPosLH(const JointState& q) { return getFootPos(q, LegID::LH); }
-    [[deprecated("This method is deprecated and will be removed. Please use getFootPos(q, LegID::RH) instead.")]]
-    virtual Vector3d getFootPosRH(const JointState& q) { return getFootPos(q, LegID::RH); }
     virtual Vector3d getFootPos  (const JointState& q, const LegID& leg) = 0;
     inline virtual LegVectorMap getFeetPos(const JointState& q)
     {

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/stance_estimator_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/stance_estimator_ros.hpp
@@ -36,5 +36,5 @@ public:
 private:
     ros::NodeHandle& nh_;
 };
-}
-}
+}  // namespace quadruped
+}  // namespace pronto

--- a/pronto_quadruped_ros/src/leg_odometer_ros.cpp
+++ b/pronto_quadruped_ros/src/leg_odometer_ros.cpp
@@ -35,7 +35,7 @@ LegOdometerROS::LegOdometerROS(ros::NodeHandle &nh,
     std::string legodo_prefix = "legodo/";
     int legodo_mode;
     if(!nh_.getParam(legodo_prefix + "legodo_mode", legodo_mode)){
-        ROS_WARN_STREAM("Could not get param \"" << legodo_prefix + "legodo_mode\"" << ". Using default.");
+        ROS_WARN_STREAM("Could not get param \"" << legodo_prefix + "legodo_mode\". Using default.");
     }
 
     // # STATIC_SIGMA 0x00, VAR_SIGMA 0x01, IMPACT_SIGMA 0x02, WEIGHTED_AVG 0x04, ALPHA_FILTER : 0x08, KALMAN_FILTER : 0x10

--- a/pronto_quadruped_ros/src/legodo_handler_ros.cpp
+++ b/pronto_quadruped_ros/src/legodo_handler_ros.cpp
@@ -272,7 +272,7 @@ LegodoHandlerBase::Update* LegodoHandlerBase::computeVelocity(){
                                                 Update::legodo,
                                                 utime_);
   } else {
-    ROS_WARN_THROTTLE(1, "[LegodoHandlerBase::computeVelocity] Could not estimate velocity");
+    if (debug_) ROS_WARN("[LegodoHandlerBase::computeVelocity] Could not estimate velocity");
   }
   return nullptr;
 }

--- a/pronto_quadruped_ros/src/legodo_handler_ros.cpp
+++ b/pronto_quadruped_ros/src/legodo_handler_ros.cpp
@@ -272,7 +272,7 @@ LegodoHandlerBase::Update* LegodoHandlerBase::computeVelocity(){
                                                 Update::legodo,
                                                 utime_);
   } else {
-    ROS_WARN("[LegodoHandlerBase::computeVelocity] Could not estimate velocity");
+    ROS_WARN_THROTTLE(1, "[LegodoHandlerBase::computeVelocity] Could not estimate velocity");
   }
   return nullptr;
 }

--- a/pronto_quadruped_ros/src/stance_estimator_ros.cpp
+++ b/pronto_quadruped_ros/src/stance_estimator_ros.cpp
@@ -87,5 +87,5 @@ StanceEstimatorROS::StanceEstimatorROS(ros::NodeHandle &nh,
     setParams(beta, stance_threshold, hysteresis_low, hysteresis_high, stance_hysteresis_delay_low, stance_hysteresis_delay_high);
 }
 
-}
-}
+}  // namespace quadruped
+}  // namespace pronto

--- a/pronto_ros/include/pronto_ros/pronto_ros_conversions.hpp
+++ b/pronto_ros/include/pronto_ros/pronto_ros_conversions.hpp
@@ -53,4 +53,4 @@ void lidarOdometryFromROS(const pronto_msgs::LidarOdometryUpdate& ros_msg,
 void forceTorqueFromROS(const pronto_msgs::BipedForceTorqueSensors& ros_msg,
                         pronto::ForceTorqueSensorArray& msg);
 
-}
+}  // namespace pronto

--- a/pronto_ros/src/lidar_odometry_ros_handler.cpp
+++ b/pronto_ros/src/lidar_odometry_ros_handler.cpp
@@ -7,7 +7,7 @@ LidarOdometryHandlerROS::LidarOdometryHandlerROS(ros::NodeHandle& nh) : use_meas
   std::string prefix = "scan_matcher/";
   std::string mode_str = "pos";
   if(!nh.getParam(prefix + "mode", mode_str)){
-    ROS_WARN_STREAM("Couldn't read param \"" << prefix << "mode" << "\". Using position.");
+    ROS_WARN_STREAM("Couldn't read param \"" << prefix << "mode\". Using position.");
   }
   if(mode_str.compare("position") == 0){
     cfg_.mode = LidarOdometryMode::POSITION;

--- a/pronto_ros/src/visual_odometry_ros_handler.cpp
+++ b/pronto_ros/src/visual_odometry_ros_handler.cpp
@@ -8,7 +8,7 @@ VisualOdometryHandlerROS::VisualOdometryHandlerROS(ros::NodeHandle& nh) {
   VisualOdometryConfig cfg;
   std::string mode_str = "pos";
   if(!nh.getParam(prefix + "mode", mode_str)){
-    ROS_WARN_STREAM("Couldn't read param \"" << prefix << "mode" << "\". Using position.");
+    ROS_WARN_STREAM("Couldn't read param \"" << prefix << "mode\". Using position.");
   }
   if(mode_str.compare("pos") == 0){
     cfg.mode = VisualOdometryMode::MODE_POSITION;

--- a/pronto_ros/src/visual_odometry_ros_handler.cpp
+++ b/pronto_ros/src/visual_odometry_ros_handler.cpp
@@ -103,4 +103,4 @@ bool VisualOdometryHandlerROS::processMessageInit(const pronto_msgs::VisualOdome
   return true;
 }
 
-}
+}  // namespace pronto

--- a/pronto_utils/src/torque_adjustment.cpp
+++ b/pronto_utils/src/torque_adjustment.cpp
@@ -56,7 +56,7 @@ void TorqueAdjustment::processSample(const std::vector<std::string>& names,
       exit(-1);
     }else{
 
-      // std::cout << "adjust " << names[pos] << " " << pos << " " << "using " << jointsToFilter[i] << " " << i << "\n";
+      // std::cout << "adjust " << names[pos] << " " << pos << " using " << jointsToFilter[i] << " " << i << "\n";
       // Apply correction. don't do the correction if filterGains_[i] is zero, NaN, or infinite.
       if (std::isnormal(filterGains_[i])) {
         positions[pos] -= magnitudeLimit( efforts[pos] / filterGains_[i]);


### PR DESCRIPTION
This PR includes:
- Simplifies the `ForwardKinematics` interface removing the requirement for redundant declarations in implementations. There is no requirement for amending existing implementations.
- Throttles the warning when leg odometry fails for easier flight phase support
- Adds a single option to toggle the debug output in ImuBiasLock (we've had a few recent PRs to comment/uncomment these lines and this is an easier way of handling things). I've also amended the messages slightly to be more clear
- Slight performance improvements in ImuBiasLock