### PR TITLE
Performance improvements for real-time control

### DIFF
--- a/pronto_biped_core/package.xml
+++ b/pronto_biped_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_biped_core</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
 
   <description>Description</description>
   <maintainer email="mfallon@robots.ox.ac.uk">Maurice Fallon</maintainer>

--- a/pronto_biped_ros/package.xml
+++ b/pronto_biped_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_biped_ros</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <description>The pronto_biped_ros package</description>
   <license>LGPLv2.1</license>
 

--- a/pronto_core/package.xml
+++ b/pronto_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>pronto_core</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <description>
     The pronto_core package contains the EKF and the main 
     modules to perform state estimation, including: inertial, gps, optical

--- a/pronto_core/src/rbis.cpp
+++ b/pronto_core/src/rbis.cpp
@@ -166,10 +166,6 @@ double matrixMeasurementGetKandCovDelta(const Eigen::MatrixXd & R,
   int m = R.rows();
 
   MatrixXd S(m, m);
-//  eigen_dump(R);
-//  eigen_dump(S);
-//  eigen_dump(C);
-//  eigen_dump(cov);
   S = R;
   S.noalias() += C * cov * C.transpose();
 

--- a/pronto_core/src/rbis_update_interface.cpp
+++ b/pronto_core/src/rbis_update_interface.cpp
@@ -77,15 +77,6 @@ void RBISIMUProcessStep::updateFilter(const RBIS & prior_state, const RBIM & pri
 #endif
 
   loglikelihood = prior_loglikelihood;
-  //    eigen_dump(prior_state);
-  //    eigen_dump(prior_cov);
-  //    eigen_dump(gyro.transpose());
-  //    eigen_dump(q_gyro);
-  //    eigen_dump(accelerometer.transpose());
-  //    eigen_dump(q_accel);
-  //    eigen_dump(posterior_state);
-  //    eigen_dump(posterior_covariance);
-  //    std::cout << std::endl;
 }
 
 void RBISIndexedMeasurement::updateFilter(const RBIS & prior_state, const RBIM & prior_cov, double prior_loglikelihood)
@@ -139,13 +130,6 @@ void RBISIndexedMeasurement::updateFilter(const RBIS & prior_state, const RBIM &
 #endif
 
   loglikelihood = prior_loglikelihood + current_loglikelihood;
-  //    eigen_dump(prior_state);
-  //    eigen_dump(prior_cov);
-  //    eigen_dump(measurement.transpose());
-  //    eigen_dump(measurement_cov);
-  //    eigen_dump(posterior_state);
-  //    eigen_dump(posterior_covariance);
-  //    std::cout << std::endl;
 }
 
 void RBISIndexedPlusOrientationMeasurement::updateFilter(const RBIS & prior_state,

--- a/pronto_core/src/state_est.cpp
+++ b/pronto_core/src/state_est.cpp
@@ -166,9 +166,6 @@ void StateEstimator::getHeadState(RBIS & head_state, RBIM & head_cov) const
   RBISUpdateInterface * head_update = history.updateMap.rbegin()->second;
   head_state = head_update->posterior_state;
   head_cov = head_update->posterior_covariance;
-
-//  eigen_dump(head_state);
-//  eigen_dump(head_cov);
 }
 
 void StateEstimator::getHeadState(const uint64_t& utime,

--- a/pronto_msgs/package.xml
+++ b/pronto_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_msgs</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
 
   <description>
 	  The pronto_msgs package contains common message types used by the

--- a/pronto_quadruped/include/pronto_quadruped/ForceSensorStanceEstimator.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/ForceSensorStanceEstimator.hpp
@@ -7,7 +7,7 @@ namespace quadruped {
 
 class ForceSensorStanceEstimator : public StanceEstimatorBase {
 public:
-  ForceSensorStanceEstimator(double force_threshold = 50) {
+  ForceSensorStanceEstimator(double /*force_threshold*/ = 50) {
   }
 
   bool getStance(LegBoolMap &stance) override;
@@ -27,6 +27,5 @@ protected:
   double force_threshold_;
 };
 
-}
-
-}
+}  // namespace quadruped
+}  // namespace pronto

--- a/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
@@ -61,38 +61,37 @@ public:
 
     void processSecondaryMessage(const pronto::JointState& msg) override;
 public:
-    inline Eigen::Vector3d getCurrentOmega() const {
+    const Eigen::Vector3d& getCurrentOmega() const {
       return current_omega_;
     }
-    inline Eigen::Vector3d getCurrentAccel() const {
+    const Eigen::Vector3d& getCurrentAccel() const {
       return current_accel_;
     }
-    inline Eigen::Vector3d getCurrentCorrectedAccel() const {
+    const Eigen::Vector3d& getCurrentCorrectedAccel() const {
       return current_accel_corrected_;
     }
 
-    inline Eigen::Vector3d getCurrentAccelBias() const {
+    const Eigen::Vector3d& getCurrentAccelBias() const {
       return accel_bias_;
     }
-    inline Eigen::Vector3d getCurrentProperAccelBias() const {
+    const Eigen::Vector3d& getCurrentProperAccelBias() const {
       return proper_accel_bias_;
     }
-    inline Eigen::Quaterniond getGVec() const {
+    const Eigen::Quaterniond& getGVec() const {
       return quat_g_vec;
     }
 
-    inline Eigen::Isometry3d getGravityTransform() const {
+    const Eigen::Isometry3d& getGravityTransform() const {
       return gravity_transform_;
     }
 
-    inline Eigen::Isometry3d getBiasTransform() const {
+    const Eigen::Isometry3d& getBiasTransform() const {
       return bias_transform_;
     }
 
     inline bool getRecordStatus() const {
       return do_record_;
     }
-
 
 protected:
     bool debug_ = false;

--- a/pronto_quadruped/include/pronto_quadruped/StanceEstimator.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/StanceEstimator.hpp
@@ -96,7 +96,7 @@ public:
                     const double& hysteresis_low = 50,
                     const double& hysteresis_high = 150);
 
-    virtual ~StanceEstimator();
+    virtual ~StanceEstimator() = default;
 
     /**
      * @brief setJointStates
@@ -143,8 +143,6 @@ public:
 
     bool getGRF(LegVectorMap& grf) override;
 
-
-
     void getGrf_W(LegVectorMap& leg_status);
 
     void getGrfDelta(LegDataMap<double>& grfDelta){
@@ -171,7 +169,6 @@ private:
     LegVectorMap grForce_W;
     LegVectorMap grForce_des;
     LegDataMap<double> grForceDelta;
-
 
     double force_threshold_;
     double falling_edge_threshold_;

--- a/pronto_quadruped/package.xml
+++ b/pronto_quadruped/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_quadruped</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <description>The pronto_quadruped package</description>
 
   <maintainer email="mcamurri@robots.ox.ac.uk">Marco Camurri</maintainer>

--- a/pronto_quadruped/src/StanceEstimator.cpp
+++ b/pronto_quadruped/src/StanceEstimator.cpp
@@ -119,8 +119,6 @@ void StanceEstimator::setParams(const std::vector<double> &beta,
     }
 }
 
-StanceEstimator::~StanceEstimator() {}
-
 void StanceEstimator::updateStat(double sample,
                                  bool is_stance,
                                  int index) {

--- a/pronto_quadruped_commons/package.xml
+++ b/pronto_quadruped_commons/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>pronto_quadruped_commons</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <description>
         pronto_quadruped_commons
   </description>

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/force_sensor_stance_estimator_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/force_sensor_stance_estimator_ros.hpp
@@ -10,9 +10,8 @@ class ForceSensorStanceEstimatorROS : public ForceSensorStanceEstimator {
 public:
   ForceSensorStanceEstimatorROS(double force_threshold = 50);
   ForceSensorStanceEstimatorROS(ros::NodeHandle& nh);
-
-
+  ~ForceSensorStanceEstimatorROS() override {}
 };
 
-}
-}
+}  // namespace quadruped
+}  // namespace pronto

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
@@ -99,7 +99,8 @@ protected:
     ros::Publisher prior_accel_debug_;
     ros::Publisher vel_sigma_bounds_pub_;
 
-    bool debug_ = true;
+    bool debug_ = true;  // Debug output including CSV output
+    bool output_log_to_file_ = true;
     geometry_msgs::WrenchStamped wrench_msg_;
     pronto_msgs::QuadrupedStance stance_msg_;
     ros::Publisher stance_pub_;

--- a/pronto_quadruped_ros/package.xml
+++ b/pronto_quadruped_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_quadruped_ros</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <description>The pronto_quadruped_ros package</description>
 
   <author email="mcamurri@robots.ox.ac.uk">Marco Camurri</author>

--- a/pronto_quadruped_ros/src/bias_lock_handler_ros.cpp
+++ b/pronto_quadruped_ros/src/bias_lock_handler_ros.cpp
@@ -35,10 +35,11 @@ RBISUpdateInterface* ImuBiasLockROS::processMessage(const sensor_msgs::Imu *msg,
 {
   msgToImuMeasurement(*msg, bias_lock_imu_msg_);
   RBISUpdateInterface* update = bias_lock_module_->processMessage(&bias_lock_imu_msg_, est);
-  RBIS head_state;
-  RBIM head_cov;
-  est->getHeadState(head_state, head_cov);
+
   if(update != nullptr){
+    RBIS head_state;
+    RBIM head_cov;
+    est->getHeadState(head_state, head_cov);
     ROS_INFO_STREAM("Bias update. Prior accel bias: " << head_state.accelBias().transpose() << std::endl
                               <<  "Prior gyro bias: " << head_state.gyroBias().transpose());
   }

--- a/pronto_ros/include/pronto_ros/ros_frontend.hpp
+++ b/pronto_ros/include/pronto_ros/ros_frontend.hpp
@@ -379,7 +379,6 @@ if(sensor_id.compare("scan_matcher") == 0){
 
             // TODO insert appropriate covariance into the message
 
-
             // set twist covariance to zero
             twist_msg_.twist.covariance.assign(0);
 

--- a/pronto_ros/include/pronto_ros/ros_frontend.hpp
+++ b/pronto_ros/include/pronto_ros/ros_frontend.hpp
@@ -365,8 +365,8 @@ if(sensor_id.compare("scan_matcher") == 0){
             // set twist covariance to zero
             twist_msg_.twist.covariance.assign(0);
 
-            Eigen::Matrix3d vel_cov = head_cov.block<3,3>(RBIS::velocity_ind,RBIS::velocity_ind);
-            Eigen::Matrix3d omega_cov = head_cov.block<3,3>(RBIS::angular_velocity_ind,RBIS::angular_velocity_ind);
+            Eigen::Block<RBIM, 3, 3> vel_cov = head_cov.block<3,3>(RBIS::velocity_ind,RBIS::velocity_ind);
+            Eigen::Block<RBIM, 3, 3> omega_cov = head_cov.block<3,3>(RBIS::angular_velocity_ind,RBIS::angular_velocity_ind);
 
             for(int i=0; i<3; i++){
               for(int j=0; j<3; j++){

--- a/pronto_ros/include/pronto_ros/ros_frontend.hpp
+++ b/pronto_ros/include/pronto_ros/ros_frontend.hpp
@@ -108,7 +108,6 @@ protected:
     void initializeState();
     void initializeCovariance();
 
-
 private:
     ros::NodeHandle& nh_;
     std::shared_ptr<StateEstimator> state_est_;
@@ -149,14 +148,10 @@ private:
 
     bool filter_initialized_ = false;
     bool verbose_ = false;
-
-
 };
-}
+}  // namespace pronto
 
 namespace pronto {
-
-
 template <class MsgT>
 void ROSFrontEnd::addInitModule(SensingModule<MsgT>& module,
                                 const SensorId& sensor_id,
@@ -280,7 +275,7 @@ template <class MsgT>
 void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& sensor_id)
 {
 #if DEBUG_MODE
-        ROS_INFO_STREAM("Callback for sensor " << sensor_id);
+    ROS_INFO_STREAM("Callback for sensor " << sensor_id);
 #endif
     // this is a generic templated callback that does the same for every module:
     // if the module is initialized and the filter is ready
@@ -291,19 +286,7 @@ void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& se
         // function to get the update
         // Record start time
 #if DEBUG_MODE
-
         auto start = std::chrono::high_resolution_clock::now();
-
-        std::cerr << sensor_id << " module address: " << active_modules_[sensor_id] << std::endl;
-        std::cerr << "message address " << msg.get() << std::endl;
-        std::cerr << "state estimator address " << state_est_.get() << std::endl;
-        std::cerr << "Before cast to SensingModule<" <<type_name<MsgT>() <<">*" << std::endl;
-        SensingModule<MsgT>* temp = static_cast<SensingModule<MsgT>*>(active_modules_[sensor_id]);
-        std::cerr << "after cast before call" << std::endl;
-        std::cerr << "address " << temp << std::endl;
-        temp->processMessage(msg.get(), state_est_.get());
-        std::cerr << "after call" << std::endl;
-
 #endif
         RBISUpdateInterface* update = static_cast<SensingModule<MsgT>*>(active_modules_[sensor_id])->processMessage(msg.get(), state_est_.get());
 #if DEBUG_MODE
@@ -432,8 +415,8 @@ if(sensor_id.compare("scan_matcher") == 0){
         }
 #if DEBUG_MODE
         else {
-                   ROS_WARN("NOT Publish head sensor ID");
-               }
+            ROS_WARN("NOT Publish head sensor ID");
+        }
         end = std::chrono::high_resolution_clock::now();
 
         ROS_INFO_STREAM("Time elapsed till the end: " << std::chrono::duration_cast<std::chrono::microseconds>(end -start).count());

--- a/pronto_ros/package.xml
+++ b/pronto_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pronto_ros</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <description>The pronto_ros package</description>
 
   <author email="mcamurri@robots.ox.ac.uk">Marco Camurri</author>

--- a/pronto_utils/include/pronto_utils/SchmittTrigger.hpp
+++ b/pronto_utils/include/pronto_utils/SchmittTrigger.hpp
@@ -25,4 +25,4 @@ private:
   double rising_edge_threshold;
   bool first_call;
 };
-}
+}  // namespace pronto

--- a/pronto_utils/package.xml
+++ b/pronto_utils/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>pronto_utils</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <description>Description</description>
   <maintainer email="mcamurri@robots.ox.ac.uk">Marco Camurri</maintainer>
   <author email="mfallon@robots.ox.ac.uk">Maurice Fallon</author>

--- a/pronto_utils/src/SchmittTrigger.cpp
+++ b/pronto_utils/src/SchmittTrigger.cpp
@@ -100,4 +100,4 @@ bool SchmittTrigger::getState() {
 double SchmittTrigger::getCurrentValue() {
   return stored_value;
 }
-}
+}  // namespace pronto


### PR DESCRIPTION
This PR brings a range of performance improvements to reduce non-deterministic behaviour that currently can lead to spikes of up to 10-20ms delay in processing state estimates. The majority of these were caused by 1) the data logger and 2) publishing debug information to topics.

Hence, I've added extra parameters to turn off publishing of debug topics, the data logger, and debug transforms. The default behaviour is the same as before - they are published unless turned off. 

I've also removed some dead code and reduced heap allocations. However, by design Pronto allocates quite a lot (e.g. each measurement and in the function to compute the covariance etc.) - this cannot easily be eliminated. Right now only about ~5-10% of computation cycles are for the actual EKF and underlying computations (when using IMU + LegOdometry + BiasLock) - the rest is communication.