### PR TITLE
Unify logging format and remove getShinPos

### DIFF
--- a/pronto_quadruped/include/pronto_quadruped/DataLogger.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/DataLogger.hpp
@@ -125,6 +125,16 @@ public:
                    const Eigen::Vector3d& omega);
 
     /**
+     * @brief writes the velocity of a rigid body at a specific time.
+     * @param time an absolute time (in seconds)
+     * @param velocity body velocity espressed in the body frame
+     * @param omega angular velocity of the body, in the body frame
+     */
+    void addSampleCSV(const double& time,
+                      const Eigen::Vector3d& velocity,
+                      const Eigen::Vector3d& omega);
+
+    /**
      * @brief writes the pose of a rigid body at a specific time.
      * @param time an absolute time (in seconds)
      * @param x x-component of the body position

--- a/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
@@ -32,6 +32,7 @@ struct ImuBiasLockConfig {
   double torque_threshold_ = 13;
   double velocity_threshold_ = 0.006;
   double dt_ = 0.0025;
+  bool verbose_ = false;
 };
 
 class ImuBiasLock : public DualSensingModule<ImuMeasurement,pronto::JointState>
@@ -95,8 +96,8 @@ public:
 
 protected:
     bool debug_ = false;
-    std::vector <Eigen::Vector3d> gyro_bias_history_;
-    std::vector <Eigen::Vector3d> accel_bias_history_;
+    std::vector<Eigen::Vector3d> gyro_bias_history_;
+    std::vector<Eigen::Vector3d> accel_bias_history_;
     bool do_record_ = true;
     bool is_static_ = false;
     size_t max_size = 3000;

--- a/pronto_quadruped/src/DataLogger.cpp
+++ b/pronto_quadruped/src/DataLogger.cpp
@@ -122,7 +122,6 @@ void DataLogger::addSample(const double &time, const Eigen::Vector3d &vec) {
         << vec(0) << "\t "
         << vec(1) << "\t "
         << vec(2) << std::endl;
-
 }
 
 void DataLogger::addSample(const double& time,
@@ -143,7 +142,6 @@ void DataLogger::addSample(const double& time,
         << rpy(0) * 180.0 / M_PI << "\t"
         << rpy(1) * 180.0 / M_PI << "\t"
         << rpy(2) * 180.0 / M_PI << "\t" << std::endl;
-
 }
 
 void DataLogger::addSample(const double& time,
@@ -185,9 +183,26 @@ void DataLogger::addSample(const double& time,
         << velocity(2) << "\t"
         << omega(0) << "\t"
         << omega(1) << "\t"
-        << omega(2) << "\t" << std::endl;
+        << omega(2) << std::endl;
 }
 
+void DataLogger::addSampleCSV(const double& time,
+                              const Eigen::Vector3d& velocity,
+                              const Eigen::Vector3d& omega){
+    if(start_from_zero && is_first_time) {
+        first_time = time;
+        is_first_time = false;
+    }
+
+    ofs << setprecision(14)
+        << time - first_time << ","
+        << velocity(0) << ","
+        << velocity(1) << ","
+        << velocity(2) << ","
+        << omega(0) << ","
+        << omega(1) << ","
+        << omega(2) << std::endl;
+}
 
 void DataLogger::addSample(double time, LegDataMap<Eigen::Vector3d> leg_vectors) {
     if(start_from_zero && is_first_time) {

--- a/pronto_quadruped/src/ImuBiasLock.cpp
+++ b/pronto_quadruped/src/ImuBiasLock.cpp
@@ -45,6 +45,7 @@ ImuBiasLock::ImuBiasLock(const Eigen::Isometry3d& ins_to_body,
   eps_ = cfg.velocity_threshold_;
   torque_threshold_ = cfg.torque_threshold_;
   dt_ = cfg.dt_;
+  debug_ = cfg.verbose_;
 
   bias_transform_ = Eigen::Isometry3d::Identity();
   gravity_transform_ = Eigen::Isometry3d::Identity();

--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/forward_kinematics.h
@@ -45,7 +45,7 @@ public:
     ForwardKinematics() = default;
     virtual ~ForwardKinematics() = default;
 
-    virtual Vector3d getFootPos  (const JointState& q, const LegID& leg) = 0;
+    virtual Vector3d getFootPos(const JointState& q, const LegID& leg) = 0;
     inline virtual LegVectorMap getFeetPos(const JointState& q)
     {
         LegVectorMap feetPos(Vector3d::Zero());
@@ -56,9 +56,6 @@ public:
         return feetPos;
     }
     virtual Matrix3d getFootOrientation(const JointState& q, const LegID& leg) = 0;
-    virtual Vector3d getShinPos(const JointState& q,
-                                const double& contact_pos,
-                                const LegID& leg) = 0;
 };
 
 }  // namespace quadruped

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/bias_lock_handler_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/bias_lock_handler_ros.hpp
@@ -113,6 +113,7 @@ ImuBiasLockBaseROS<JointStateT>::ImuBiasLockBaseROS(ros::NodeHandle& nh) : nh_(n
   quadruped::ImuBiasLockConfig cfg;
   nh_.getParam(lock_param_prefix + "torque_threshold", cfg.torque_threshold_);
   nh_.getParam(lock_param_prefix + "velocity_threshold", cfg.velocity_threshold_);
+  nh_.param<bool>(lock_param_prefix + "verbose", cfg.verbose_, false);
 
   if(!nh_.getParam(ins_param_prefix + "timestep_dt", cfg.dt_)){
     ROS_WARN_STREAM("Couldn't read dt. Using default: " << cfg.dt_);

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/legodo_handler_ros.hpp
@@ -86,8 +86,8 @@ protected:
     uint64_t utime_;  // time in microseconds
     uint64_t nsec_;   // time in nanoseconds
 
-    uint16_t downsample_factor_;
-    uint64_t utime_offset_;
+    uint16_t downsample_factor_ = 1;
+    uint64_t utime_offset_ = 0;
 
     // Debug Publishers
     std::vector<ros::Publisher> vel_debug_;

--- a/pronto_quadruped_ros/src/legodo_handler_ros.cpp
+++ b/pronto_quadruped_ros/src/legodo_handler_ros.cpp
@@ -42,8 +42,10 @@ LegodoHandlerBase::LegodoHandlerBase(ros::NodeHandle &nh,
 {
     const std::string prefix = "legodo/";
 
-    nh.getParam(prefix + "downsample_factor", (int&)downsample_factor_);
-    nh.getParam(prefix + "utime_offset", (int&)utime_offset_);
+    nh.param<int>(prefix + "downsample_factor", (int&)downsample_factor_, 1);
+    nh.param<int>(prefix + "utime_offset", (int&)utime_offset_, 0);
+    ROS_INFO_STREAM("[LegodoHandler] downsample_factor = " << downsample_factor_ << "\n" <<
+                    "                utime_offset =      " << utime_offset_);
 
     double r_vx;
     double r_vy;

--- a/pronto_quadruped_ros/src/legodo_handler_ros.cpp
+++ b/pronto_quadruped_ros/src/legodo_handler_ros.cpp
@@ -134,14 +134,14 @@ void LegodoHandlerBase::getPreviousState(const StateEstimator *est)
     if(output_log_to_file_) {
       double time = static_cast<double>(head_state_.utime) * 1e-6;
       dl_pose_->addSampleCSV(time, head_state_.position(), orientation_);
-      dl_vel_->addSample(time, head_state_.velocity(), head_state_.angularVelocity());
+      dl_vel_->addSampleCSV(time, head_state_.velocity(), head_state_.angularVelocity());
 
       Eigen::Block<RBIM, 3, 3> vel_cov = head_cov_.block<3,3>(RBIS::velocity_ind, RBIS::velocity_ind);
       Eigen::Block<RBIM, 3, 3> omega_cov = head_cov_.block<3,3>(RBIS::angular_velocity_ind, RBIS::angular_velocity_ind);
 
       Vector3d vel_sigma = vel_cov.diagonal().array().sqrt().matrix();
       Vector3d omega_sigma = omega_cov.diagonal().array().sqrt().matrix();
-      dl_vel_sigma_->addSample(time, vel_sigma, omega_sigma);
+      dl_vel_sigma_->addSampleCSV(time, vel_sigma, omega_sigma);
     }
 }
 


### PR DESCRIPTION
- Adds ability to turn bias lock verbosity off from config file (parameter "verbose")
- Unifies logged files to CSV - before they were CSV for position, TSV for velocity (with redundant tab before line break breaking Pandas's parser). Note, this changes the output of `prontovel.txt` and `velsigma.txt` to CSV
- Removes `getShinPos` from `ForwardKinematics` to simplify the interface (it was unused and defaulted to `getFootPos` in every implementation I've seen